### PR TITLE
Fix Issues #46 & #47

### DIFF
--- a/panels/player/player personal details popup panel.xml
+++ b/panels/player/player personal details popup panel.xml
@@ -11,15 +11,19 @@
 		<container >
 			<layout class="stick_to_sides_attachment" apply_to_children="true"/>
 
-			<!-- STATUS INDICATORS -->
-			<widget class="player_status_all_button" id="psAB" maximised="true" auto_size="vertical" alignment="bottom" gap="-2" max_items_per_row_or_column="6">
-				<layout class="stick_to_sides_attachment" alignment="top,right" inset="0,2"/>
-				<record id="object_property" get_property="Pnfa"/>
-			</widget>
-
+			<!-- PLAYER PICTURE -->
 			<widget class="object_portrait_picture" id="face" width="100" image_alignment="left,bottom" scale_picture="true" keep_aspect_ratio="true">
 				<record id="object_property" get_property="objt"/>
 			</widget>
+
+			<!-- STATUS INDICATORS-->
+			<!-- Fix Issue #46 changed order, and added a container to give it the right placeholder, and maintain the picture as clickable -->
+			<container>
+				<widget class="player_status_all_button" id="psAB" maximised="true" auto_size="vertical" alignment="bottom" gap="-2" max_items_per_row_or_column="6">
+					<layout class="stick_to_sides_attachment" alignment="top,right" inset="0,2"/>
+					<record id="object_property" get_property="Pnfa"/>
+				</widget>
+			</container>
 		</container>
 
 		<!-- CLUB AND NATION LOGO -->

--- a/panels/player/tcs/selector/header/playerpic/faceonly.xml
+++ b/panels/player/tcs/selector/header/playerpic/faceonly.xml
@@ -4,13 +4,22 @@
 	<boolean id="should_force_refresh" value="true"/>
 
 	<!-- Status Indicators -->
-	<widget class="player_status_all_button" id="psAB" maximised="true" auto_size="vertical" alignment="bottom" gap="-2" max_items_per_row_or_column="6">
-		<layout class="stick_to_sides_attachment" alignment="top,right" inset="0,2"/>
-		<record id="object_property" get_property="Pnfa"/>
-	</widget>
+	<!-- Fix Issue #47, Added containers to both widgets, and give them the horizontal alignment to make them properly aligned -->
+	<container>
+		<attachment_group class="horizontal_arrange" horizontal_alignment="left,extend"/>
+		<widget class="player_status_all_button" id="psAB" maximised="true" auto_size="vertical" alignment="bottom" gap="-2" max_items_per_row_or_column="6">
+			<layout class="stick_to_sides_attachment" alignment="top,right" inset="0,2"/>
+			<record id="object_property" get_property="Pnfa"/>
+		</widget>
+	</container>
 
-	<widget class="object_portrait_picture" id="face" width="180" image_alignment="middle_x,bottom" scale_picture="true" keep_aspect_ratio="true">
-		<record id="object_property" get_property="objt"/>
-	</widget>
+	<container>
+		<attachment_group class="horizontal_arrange" horizontal_alignment="fill" horizontal_offset="25" horizontal_gap="0" vertical_inset="0" />
 
+		<widget class="object_portrait_picture" id="face" width="180" image_alignment="middle_x,bottom" scale_picture="true" keep_aspect_ratio="true">
+			<record id="object_property" get_property="objt"/>
+		</widget>
+	</container>
+
+	
 </panel>


### PR DESCRIPTION
We can now see, and click on the status indicators within the popup. Fix Issue #46
![image](https://github.com/bluestillidie00/tcs5/assets/7164089/3ac38278-3041-46ae-bfac-b34e67f5a907)


Now you can mouse over on the status indicators within the player profile, when faceonly option is selected. Fix Issue #47
![image](https://github.com/bluestillidie00/tcs5/assets/7164089/bfc0f387-6a3b-4d71-9e4e-0e27bca735e9)
