### PR TITLE
Added passmaps instead of heatmaps in match in between highlights panel

### DIFF
--- a/MODS/D. Match Screens/C. v1.3 Match Layout/panels/match/match in between highlights panel.xml
+++ b/MODS/D. Match Screens/C. v1.3 Match Layout/panels/match/match in between highlights panel.xml
@@ -183,7 +183,7 @@
 										</container>
 									</container>
 
-									<widget class="match_analysis_panel" id="Anal" file="match/tcs/tablet/heatmaps">
+									<widget class="match_analysis_panel" id="Anal" file="match/tcs/tablet/passmaps">
 										<!-- Slide in from side of screen -->
 										<animation class="translate_animation" trigger_id="hidden" trigger_value="false" start_value="0,1" end_value="0,0" duration="0.35" end_mode="hold_auto_reverse_hold" tween="ease_out" coord_mode="relative_to_screen" apply_to_mouse="false"/>
 										<animation class="fade_on_hide_animation" duration="0.35"/>

--- a/panels/match/match in between highlights panel.xml
+++ b/panels/match/match in between highlights panel.xml
@@ -183,7 +183,7 @@
 										</container>
 									</container>
 
-									<widget class="match_analysis_panel" id="Anal" file="match/tcs/tablet/heatmaps">
+									<widget class="match_analysis_panel" id="Anal" file="match/tcs/tablet/passmaps">
 										<!-- Slide in from side of screen -->
 										<animation class="translate_animation" trigger_id="hidden" trigger_value="false" start_value="0,1" end_value="0,0" duration="0.35" end_mode="hold_auto_reverse_hold" tween="ease_out" coord_mode="relative_to_screen" apply_to_mouse="false"/>
 										<animation class="fade_on_hide_animation" duration="0.35"/>

--- a/panels/match/tcs/tablet/passmaps.xml
+++ b/panels/match/tcs/tablet/passmaps.xml
@@ -1,0 +1,47 @@
+<!-- custom panel for ibh review screen - passmap and best/worst performers -->
+<panel>
+    <layout class="stick_to_sides_attachment" alignment="all" inset="0" apply_to_children="true" />
+    <!-- Team Analysis -->
+    <container class="plain_box" draw_vertical_dividers="true">
+
+        <layout class="arrange_horizontal_attachment" layout="-1,-1" offset="0" />
+        <layout class="stick_to_sides_attachment" alignment="vertical" inset="4" apply_to_children="true" />
+
+        <!--home pass map-->
+        <container>
+            <layout class="arrange_vertical_attachment" alignment="top,extend" offset="0" gap="0"/>
+            <layout class="stick_to_sides_attachment" alignment="horizontal" inset="0" apply_to_children="true" />
+
+
+            <!--pass map-->
+            <widget class="preselected_match_chalkboard_panel" id="pmcH" vertical="true" force_left_to_right_events="true" team_to_display="0" average_position_filter="1" aHiL="false" wants_global_events="false" enable_popup="false">
+                <record id="object_property" get_property="objt" set_property="objt" />
+                <list id="chalkboard_events_to_display">
+                    <!-- Passmap -->
+                    <integer value="42" />
+                    <integer value="63" />
+                </list>
+            </widget>
+
+        </container>
+
+        <!--away pass map-->
+        <container>
+
+            <layout class="arrange_vertical_attachment" alignment="top,extend" offset="0" gap="0"/>
+            <layout class="stick_to_sides_attachment" alignment="horizontal" inset="0" apply_to_children="true" />
+
+			<!--pass map-->
+            <widget class="preselected_match_chalkboard_panel" id="pmcA" vertical="true" force_left_to_right_events="true" team_to_display="1" average_position_filter="1" aHiL="false" wants_global_events="false" enable_popup="false">
+                <record id="object_property" get_property="objt" set_property="objt" />
+                <list id="chalkboard_events_to_display">
+                    <!-- Passmap -->
+                    <integer value="42" />
+                    <integer value="63" />
+                </list>
+            </widget>
+
+        </container>
+
+    </container>
+</panel>


### PR DESCRIPTION
This pull request introduces a new feature to the match in-between highlights panel, replacing heat maps with pass maps. The pass maps provide a more detailed and informative visualization of the game, allowing users to better understand the flow of the match.
Before:
![image](https://github.com/user-attachments/assets/3103c44a-8e40-4388-93e0-605b60ab5515)
After:
![image](https://github.com/user-attachments/assets/32ee497d-6469-4b95-9a66-0ea3216b0336)
